### PR TITLE
Scripts debug

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -16,7 +16,7 @@ tasks:
 # VScode xdebug extension
 vscode:
   extensions:
-    - felixfbecker.php-debug@1.13.0:WX8Y3EpQk3zgahy41yJtNQ==
+    - felixfbecker.php-debug@1.13.0
 
 ports:
   # Used by projector

--- a/.gitpod/download-ddev-images.sh
+++ b/.gitpod/download-ddev-images.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+if $DEBUG_DRUPALPOD; then
+    set -x
+fi
 
 ddev version | awk '/(drud|phpmyadmin)/ {print $2;}' >/tmp/images.txt
 for item in $(cat /tmp/images.txt); do

--- a/.gitpod/download-ddev-images.sh
+++ b/.gitpod/download-ddev-images.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-if $DEBUG_DRUPALPOD; then
+if [ -n "$DEBUG_DRUPALPOD" ]; then
     set -x
 fi
 

--- a/.gitpod/download-ddev-images.sh
+++ b/.gitpod/download-ddev-images.sh
@@ -4,6 +4,7 @@ if $DEBUG_DRUPALPOD; then
 fi
 
 ddev version | awk '/(drud|phpmyadmin)/ {print $2;}' >/tmp/images.txt
-for item in $(cat /tmp/images.txt); do
-  docker pull $item
-done
+while IFS= read -r item
+do
+  docker pull "$item"
+done < <(cat /tmp/images.txt)

--- a/.gitpod/drupal/pull-issue-fork.sh
+++ b/.gitpod/drupal/pull-issue-fork.sh
@@ -5,7 +5,9 @@ fi
 
 # Add git.drupal.org to known_hosts
 mkdir -p ~/.ssh
-ssh-keyscan git.drupal.org >> ~/.ssh/known_hosts
+host=git.drupal.org
+SSHKey=$(ssh-keyscan $host 2> /dev/null)
+echo "$SSHKey" >> ~/.ssh/known_hosts
 
 # Set clone mode (SSH/HTTPS)
 SSH_CLONE="git@git.drupal.org:"

--- a/.gitpod/drupal/pull-issue-fork.sh
+++ b/.gitpod/drupal/pull-issue-fork.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-if $DEBUG_DRUPALPOD; then
+if [ -n "$DEBUG_DRUPALPOD" ]; then
     set -x
 fi
 

--- a/.gitpod/drupal/pull-issue-fork.sh
+++ b/.gitpod/drupal/pull-issue-fork.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-set -x
+if $DEBUG_DRUPALPOD; then
+    set -x
+fi
 
 # Add git.drupal.org to known_hosts
 mkdir -p ~/.ssh

--- a/.gitpod/drupal/ssh/01-check-private-ssh.sh
+++ b/.gitpod/drupal/ssh/01-check-private-ssh.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-set -x
+if $DEBUG_DRUPALPOD; then
+    set -x
+fi
 
 # Check if ~/.ssh/id_rsa already exist
 if [ -f ~/.ssh/id_rsa ]; then

--- a/.gitpod/drupal/ssh/01-check-private-ssh.sh
+++ b/.gitpod/drupal/ssh/01-check-private-ssh.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-if $DEBUG_DRUPALPOD; then
+if [ -n "$DEBUG_DRUPALPOD" ]; then
     set -x
 fi
 

--- a/.gitpod/drupal/ssh/02-setup-private-ssh.sh
+++ b/.gitpod/drupal/ssh/02-setup-private-ssh.sh
@@ -7,7 +7,9 @@ SSH_SETUP_REQUIRED=true
 
 # Add git.drupal.org to known_hosts
 mkdir -p ~/.ssh
-ssh-keyscan git.drupal.org >> ~/.ssh/known_hosts
+host=git.drupal.org
+SSHKey=$(ssh-keyscan $host 2> /dev/null)
+echo "$SSHKey" >> ~/.ssh/known_hosts
 
 # Validate private SSH key in Gitpod with public SSH key in drupal.org
 if ssh -T git@git.drupal.org; then

--- a/.gitpod/drupal/ssh/02-setup-private-ssh.sh
+++ b/.gitpod/drupal/ssh/02-setup-private-ssh.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+if $DEBUG_DRUPALPOD; then
+    set -x
+fi
 
 SSH_SETUP=true
 

--- a/.gitpod/drupal/ssh/02-setup-private-ssh.sh
+++ b/.gitpod/drupal/ssh/02-setup-private-ssh.sh
@@ -3,7 +3,7 @@ if $DEBUG_DRUPALPOD; then
     set -x
 fi
 
-SSH_SETUP=true
+SSH_SETUP_REQUIRED=true
 
 # Add git.drupal.org to known_hosts
 mkdir -p ~/.ssh
@@ -13,11 +13,11 @@ ssh-keyscan git.drupal.org >> ~/.ssh/known_hosts
 if ssh -T git@git.drupal.org; then
       read -r -p "SSH key was already confirmed with Drupal.org, are you sure you want to recreate SSH key? [y/N]" setup_ssh
       if [ "$setup_ssh" != "y" ] && [ "$setup_ssh" != "Y" ]; then
-            SSH_SETUP=false
+            SSH_SETUP_REQUIRED=false
       fi
 fi
 
-if [ "$SSH_SETUP" ]; then
+if $SSH_SETUP_REQUIRED; then
       # Create ssh key pairing + instructions to paste public key in drupal.org
       ssh-keygen -q -t rsa -b 4096 -f ~/.ssh/id_rsa
       .gitpod/drupal/ssh/03-generate-drupal-ssh-instructions.sh

--- a/.gitpod/drupal/ssh/02-setup-private-ssh.sh
+++ b/.gitpod/drupal/ssh/02-setup-private-ssh.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-if $DEBUG_DRUPALPOD; then
+if [ -n "$DEBUG_DRUPALPOD" ]; then
     set -x
 fi
 

--- a/.gitpod/drupal/ssh/03-generate-drupal-ssh-instructions.sh
+++ b/.gitpod/drupal/ssh/03-generate-drupal-ssh-instructions.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+if $DEBUG_DRUPALPOD; then
+    set -x
+fi
 
 # create instructions file with user's public key
 cat ~/.ssh/id_rsa.pub > /workspace/public_key.md

--- a/.gitpod/drupal/ssh/03-generate-drupal-ssh-instructions.sh
+++ b/.gitpod/drupal/ssh/03-generate-drupal-ssh-instructions.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-if $DEBUG_DRUPALPOD; then
+if [ -n "$DEBUG_DRUPALPOD" ]; then
     set -x
 fi
 

--- a/.gitpod/drupal/ssh/04-confirm-ssh-setup.sh
+++ b/.gitpod/drupal/ssh/04-confirm-ssh-setup.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+if $DEBUG_DRUPALPOD; then
+    set -x
+fi
 
 # Add git.drupal.org to known_hosts
 mkdir -p ~/.ssh

--- a/.gitpod/drupal/ssh/04-confirm-ssh-setup.sh
+++ b/.gitpod/drupal/ssh/04-confirm-ssh-setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-if $DEBUG_DRUPALPOD; then
+if [ -n "$DEBUG_DRUPALPOD" ]; then
     set -x
 fi
 

--- a/.gitpod/drupal/ssh/04-confirm-ssh-setup.sh
+++ b/.gitpod/drupal/ssh/04-confirm-ssh-setup.sh
@@ -5,7 +5,9 @@ fi
 
 # Add git.drupal.org to known_hosts
 mkdir -p ~/.ssh
-ssh-keyscan git.drupal.org >> ~/.ssh/known_hosts
+host=git.drupal.org
+SSHKey=$(ssh-keyscan $host 2> /dev/null)
+echo "$SSHKey" >> ~/.ssh/known_hosts
 
 # Validate private SSH key in Gitpod with public SSH key in drupal.org
 if ssh -T git@git.drupal.org; then

--- a/.gitpod/drupal/ssh/05-set-repo-as-ssh.sh
+++ b/.gitpod/drupal/ssh/05-set-repo-as-ssh.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-set -x
+if $DEBUG_DRUPALPOD; then
+    set -x
+fi
 
 # Set WORK_DIR
 if [ "$DP_PROJECT_TYPE" == "project_core" ]; then

--- a/.gitpod/drupal/ssh/05-set-repo-as-ssh.sh
+++ b/.gitpod/drupal/ssh/05-set-repo-as-ssh.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-if $DEBUG_DRUPALPOD; then
+if [ -n "$DEBUG_DRUPALPOD" ]; then
     set -x
 fi
 

--- a/.gitpod/phpstorm.sh
+++ b/.gitpod/phpstorm.sh
@@ -3,4 +3,4 @@
 if [ ! -x ~/.projector/configs/PhpStorm/run.sh ]; then
   echo "PhpStorm runner not found" && exit 1
 fi
-~/.projector/configs/PhpStorm/run.sh $GITPOD_REPO_ROOT
+~/.projector/configs/PhpStorm/run.sh "$GITPOD_REPO_ROOT"

--- a/.gitpod/setup-ddev.sh
+++ b/.gitpod/setup-ddev.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+if $DEBUG_DRUPALPOD; then
+    set -x
+fi
 
 # Set up ddev for use on gitpod
 

--- a/.gitpod/setup-ddev.sh
+++ b/.gitpod/setup-ddev.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-if $DEBUG_DRUPALPOD; then
+if [ -n "$DEBUG_DRUPALPOD" ]; then
     set -x
 fi
 

--- a/.gitpod/setup-ddev.sh
+++ b/.gitpod/setup-ddev.sh
@@ -12,7 +12,7 @@ DDEV_DIR="${GITPOD_REPO_ROOT}/.ddev"
 # proxied ports so they're known to ddev.
 shortgpurl="${GITPOD_WORKSPACE_URL#'https://'}"
 
-cat <<CONFIGEND > ${DDEV_DIR}/config.gitpod.yaml
+cat <<CONFIGEND > "${DDEV_DIR}"/config.gitpod.yaml
 #ddev-gitpod-generated
 use_dns_when_possible: false
 # Throwaway ports, otherwise Gitpod throw an error 'port needs to be > 1024'
@@ -28,7 +28,7 @@ CONFIGEND
 # So add it via docker-compose.host-docker-internal.yaml
 hostip=$(awk "\$2 == \"$HOSTNAME\" { print \$1; }" /etc/hosts)
 
-cat <<COMPOSEEND >${DDEV_DIR}/docker-compose.host-docker-internal.yaml
+cat <<COMPOSEEND >"${DDEV_DIR}"/docker-compose.host-docker-internal.yaml
 #ddev-gitpod-generated
 version: "3.6"
 services:


### PR DESCRIPTION
# The Problem/Issue/Bug
Scripts display too much information by default

## How this PR Solves The Problem
Add `DEBUG_DRUPALPOD` env variable, only when its true - verbose debug infromation is being displayed. 

## Manual Testing Instructions

## Related Issue Link(s)

## Release/Deployment notes
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->


<a href="https://gitpod.io/#https://github.com/shaal/DrupalPod/pull/9"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

