### PR TITLE
Ask for SSH keyphrase only once

### DIFF
--- a/.gitpod/drupal/ssh/01-check-private-ssh.sh
+++ b/.gitpod/drupal/ssh/01-check-private-ssh.sh
@@ -19,7 +19,7 @@ else
             echo "Setting SSH key from environment variable"
             mkdir -p ~/.ssh
             # Due to bug in gp env command, replace `=` with `_` - https://github.com/gitpod-io/gitpod/issues/4493
-            printenv DRUPAL_SSH_KEY | sed 's/_/=/g' >  ~/.ssh/id_rsa
+            printenv DRUPAL_SSH_KEY > ~/.ssh/id_rsa
             chmod 600 ~/.ssh/id_rsa
       fi
       # Ask for SSH keyphrase only once

--- a/.gitpod/drupal/ssh/01-check-private-ssh.sh
+++ b/.gitpod/drupal/ssh/01-check-private-ssh.sh
@@ -18,7 +18,6 @@ else
       else
             echo "Setting SSH key from environment variable"
             mkdir -p ~/.ssh
-            # Due to bug in gp env command, replace `=` with `_` - https://github.com/gitpod-io/gitpod/issues/4493
             printenv DRUPAL_SSH_KEY > ~/.ssh/id_rsa
             chmod 600 ~/.ssh/id_rsa
       fi

--- a/.gitpod/drupal/ssh/01-check-private-ssh.sh
+++ b/.gitpod/drupal/ssh/01-check-private-ssh.sh
@@ -22,4 +22,9 @@ else
             printenv DRUPAL_SSH_KEY | sed 's/_/=/g' >  ~/.ssh/id_rsa
             chmod 600 ~/.ssh/id_rsa
       fi
+      # Ask for SSH keyphrase only once
+      if ssh-add -l > /dev/null ; then
+            eval "$(ssh-agent -s)" > /dev/null
+            ssh-add -q ~/.ssh/id_rsa
+      fi
 fi

--- a/.gitpod/drupal/ssh/04-confirm-ssh-setup.sh
+++ b/.gitpod/drupal/ssh/04-confirm-ssh-setup.sh
@@ -18,10 +18,8 @@ fi
 # Validate private SSH key in Gitpod with public SSH key in drupal.org
 if ssh -T git@git.drupal.org; then
     echo "Setup was succesful, saving your private key in Gitpod"
-    # Set Gitpod variable anvironment
-    # Remove all newline characters from SSH key
-    # + Due to bug in gp env command, replace ` ` with `\ ` - https://github.com/gitpod-io/gitpod/issues/4736
-    gp env "DRUPAL_SSH_KEY=$(tr -d '\n' < ~/.ssh/id_rsa | sed 's/ /\\ /g')" > /dev/null
+    # Set private SSH key as Gitpod variable anvironment
+    gp env "DRUPAL_SSH_KEY=$(cat ~/.ssh/id_rsa)" > /dev/null
     # Copy key to /workspace in case this workspace times out
     cp ~/.ssh/id_rsa /workspace/.
     # Set repo remote branch to SSH (in case it was added as HTTPS)

--- a/.gitpod/drupal/ssh/04-confirm-ssh-setup.sh
+++ b/.gitpod/drupal/ssh/04-confirm-ssh-setup.sh
@@ -19,9 +19,9 @@ fi
 if ssh -T git@git.drupal.org; then
     echo "Setup was succesful, saving your private key in Gitpod"
     # Set Gitpod variable anvironment
-    # Due to bug in gp env command, replace `=` with `_` - https://github.com/gitpod-io/gitpod/issues/4493
-    DRUPAL_SSH_KEY=$(sed 's/=/_/g' ~/.ssh/id_rsa)
-    gp env "DRUPAL_SSH_KEY=$DRUPAL_SSH_KEY" > /dev/null
+    # Remove all newline characters from SSH key
+    # + Due to bug in gp env command, replace ` ` with `\ ` - https://github.com/gitpod-io/gitpod/issues/4736
+    gp env "DRUPAL_SSH_KEY=$(tr -d '\n' < ~/.ssh/id_rsa | sed 's/ /\\ /g')"
     # Copy key to /workspace in case this workspace times out
     cp ~/.ssh/id_rsa /workspace/.
     # Set repo remote branch to SSH (in case it was added as HTTPS)

--- a/.gitpod/drupal/ssh/04-confirm-ssh-setup.sh
+++ b/.gitpod/drupal/ssh/04-confirm-ssh-setup.sh
@@ -9,6 +9,12 @@ host=git.drupal.org
 SSHKey=$(ssh-keyscan $host 2> /dev/null)
 echo "$SSHKey" >> ~/.ssh/known_hosts
 
+# Ask for SSH keyphrase only once
+if ssh-add -l > /dev/null ; then
+    eval "$(ssh-agent -s)" > /dev/null
+    ssh-add -q ~/.ssh/id_rsa
+fi
+
 # Validate private SSH key in Gitpod with public SSH key in drupal.org
 if ssh -T git@git.drupal.org; then
     echo "Setup was succesful, saving your private key in Gitpod"

--- a/.gitpod/drupal/ssh/04-confirm-ssh-setup.sh
+++ b/.gitpod/drupal/ssh/04-confirm-ssh-setup.sh
@@ -21,7 +21,7 @@ if ssh -T git@git.drupal.org; then
     # Set Gitpod variable anvironment
     # Remove all newline characters from SSH key
     # + Due to bug in gp env command, replace ` ` with `\ ` - https://github.com/gitpod-io/gitpod/issues/4736
-    gp env "DRUPAL_SSH_KEY=$(tr -d '\n' < ~/.ssh/id_rsa | sed 's/ /\\ /g')"
+    gp env "DRUPAL_SSH_KEY=$(tr -d '\n' < ~/.ssh/id_rsa | sed 's/ /\\ /g')" > /dev/null
     # Copy key to /workspace in case this workspace times out
     cp ~/.ssh/id_rsa /workspace/.
     # Set repo remote branch to SSH (in case it was added as HTTPS)


### PR DESCRIPTION
# The Problem/Issue/Bug
During the process of setting up the workspace, SSH keyphrase might be asked more than once.

## How this PR Solves The Problem
Adds private key identities to the OpenSSH authentication agent

## Manual Testing Instructions
* Set up new SSH access with drupal.org, confirm you are asked only once for your passphrase.
* Use DrupalPod extension from a drupal.org issue page, and confirm that when workspace opens - you are only asked once for you passphrase.

## Related Issue Link(s)

## Release/Deployment notes
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->


<a href="https://gitpod.io/#https://github.com/shaal/DrupalPod/pull/11"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

