### PR TITLE
Support module versions

### DIFF
--- a/.gitpod/.gitpod.Dockerfile
+++ b/.gitpod/.gitpod.Dockerfile
@@ -27,5 +27,5 @@ RUN sudo php composer-setup.php --install-dir /usr/bin --filename composer
 RUN php -r "unlink('composer-setup.php');"
 
 ###
-### Initiate a rebuild of Gitpod's image by updating this comment #2
+### Initiate a rebuild of Gitpod's image by updating this comment #3
 ###

--- a/.gitpod/drupal/pull-issue-fork.sh
+++ b/.gitpod/drupal/pull-issue-fork.sh
@@ -77,6 +77,10 @@ if [ "$DP_PROJECT_TYPE" != "project_core" ]; then
     cd "${GITPOD_REPO_ROOT}"/repos/drupal && git checkout "${DP_CORE_VERSION}"
 fi
 
+if [ -n "$DP_MODULE_VERSION" ]; then
+    cd "${WORK_DIR}" && git checkout "$DP_MODULE_VERSION"
+fi
+
 if [ -n "$DP_PATCH_FILE" ]; then
     echo Applying selected patch "$DP_PATCH_FILE"
     cd "${WORK_DIR}" && curl "$DP_PATCH_FILE" | patch -p1


### PR DESCRIPTION
# The Problem/Issue/Bug
Opening an issue of a module that has multiple versions - DrupalPod would git clone only the default module version.

## How this PR Solves The Problem
This PR adds a variable to DrupalPod that identifies the branch version of the module.
(In additional, the DrupalPod extension has a new functionality - read the module version from the issue page.)

This PR fixes #12 

## Manual Testing Instructions

## Related Issue Link(s)

## Release/Deployment notes
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->


<a href="https://gitpod.io/#https://github.com/shaal/DrupalPod/pull/13"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

