### PR TITLE
adding AWS - database backup/restore

### DIFF
--- a/.gitpod/.gitpod.Dockerfile
+++ b/.gitpod/.gitpod.Dockerfile
@@ -20,6 +20,11 @@ RUN brew install gitui
 # Install dialog (interactive script)
 RUN brew install dialog
 
+# Install AWS CLI
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+sudo ./aws/install
+
 # Install latest composer
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
 RUN php -r "if (hash_file('sha384', 'composer-setup.php') === '756890a4488ce9024fc62c56153228907f1545c228516cbf63f885e036d37e9a59d27d63f46af1d4d07ee0f76181c7d3') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"

--- a/.gitpod/.gitpod.Dockerfile
+++ b/.gitpod/.gitpod.Dockerfile
@@ -21,9 +21,7 @@ RUN brew install gitui
 RUN brew install dialog
 
 # Install AWS CLI
-curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-unzip awscliv2.zip
-sudo ./aws/install
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && sudo ./aws/install
 
 # Install latest composer
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"

--- a/.gitpod/aws/aws-backup.sh
+++ b/.gitpod/aws/aws-backup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+
+if [ -n "$DEBUG_DRUPALPOD" ]; then
+    set -x
+fi
+
+# Check that an AWS bucket name was defined
+if [ -n "$AWS_DEFAULT_BUCKET" ]; then
+    # User defined backup
+    if [ -n "$1" ]; then
+        BACKUP_NAME=$1
+    else
+        # Default backup_name - current UTC date & time
+        BACKUP_NAME=$(date +"%Y-%m-%d__%H-%M-%S")
+    fi
+    ddev snapshot --name "$BACKUP_NAME"
+    tar zcf /tmp/"$BACKUP_NAME".tar.gz .ddev/db_snapshots/"$BACKUP_NAME"
+    aws s3 mv /tmp/"$BACKUP_NAME".tar.gz s3://"$AWS_DEFAULT_BUCKET"
+else
+    echo "No bucket defined in AWS_DEFAULT_BUCKET"
+    exit 1
+fi

--- a/.gitpod/aws/aws-restore.sh
+++ b/.gitpod/aws/aws-restore.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+
+if [ -n "$DEBUG_DRUPALPOD" ]; then
+    set -x
+fi
+
+# Check that an AWS bucket name was defined
+if [ -n "$AWS_DEFAULT_BUCKET" ]; then
+    if [ -n "$1" ]; then
+        # Specific backup
+        BACKUP_NAME=$1
+    else
+        # Latest backup
+        ALL_FILES=$(aws s3 ls "$AWS_DEFAULT_BUCKET"); LATEST_BACKUP_FILE=$(echo "$ALL_FILES" | sort -r | awk 'NR==1 {print $NF}'); echo "$LATEST_BACKUP_FILE"
+        BACKUP_NAME=$(echo "$LATEST_BACKUP_FILE" | tr -d '.tar.gz')
+    fi
+    if ! [ -d .ddev/db_snapshots/"$BACKUP_NAME" ]; then
+        BACKUP_FILE=$BACKUP_NAME.tar.gz
+        mkdir -p .ddev/db_snapshots
+        aws s3 cp s3://"$AWS_DEFAULT_BUCKET"/"$BACKUP_FILE" /tmp/.
+        tar xzf /tmp/"$BACKUP_FILE"
+    fi
+    ddev snapshot restore "$BACKUP_NAME"
+else
+    echo "No bucket defined in AWS_DEFAULT_BUCKET"
+    exit 1
+fi


### PR DESCRIPTION
# The Problem/Issue/Bug
It's not possible to maintain consistent database across workspaces.

## How this PR Solves The Problem
Add AWS commands:
`.gitpod/aws/aws-backup.sh [backup_name]`
`.gitpod/aws/aws-restore.sh [backup_name]`

## Manual Testing Instructions
1. Create new Gitpod Environment variables through CLI (or directly in https://gitpod.io/variables)
`gp env AWS_ACCESS_KEY_ID=[ID]`
`gp env AWS_SECRET_ACCESS_KEY=[SECRET]`
`gp env AWS_DEFAULT_BUCKET=[BUCKET_NAME]`
1. open a new workspace (or stop/start current workspace, for `gp env` to take effect)
1. Make some changes in current website.
1. Run `aws-backup.sh testing123` (for a named backup)
1. Make additional changes in current website.
1. Run `aws-backup.sh` (for general backup, to be used later in Gitpod's future end-tasks)
1. Close workspace
1. Open a new workspace
1. Run `aws-restore.sh testing123` (for restoring the named backup)
1. Confirm first changes are in the website, after its DB was restored.
1. Run `aws-restore.sh` (for restoring the latest backup available)
1. Confirm second changes are in the website, after its DB was restored.

## Related Issue Link(s)

## Release/Deployment notes
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->


<a href="https://gitpod.io/#https://github.com/shaal/DrupalPod/pull/18"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

