### PR TITLE
Install latest projector-tested PhpStorm version

### DIFF
--- a/.gitpod/.gitpod.Dockerfile
+++ b/.gitpod/.gitpod.Dockerfile
@@ -8,7 +8,7 @@ RUN sudo apt-get -qq install -y patchutils python3 python3-pip libxext6 libxrend
 RUN pip3 install projector-installer
 # Install PhpStorm
 RUN mkdir -p ~/.projector/configs  # Prevents projector install from asking for the license acceptance
-RUN projector install 'PhpStorm 2021.1.3' --no-auto-run
+RUN projector install 'PhpStorm 2020.3.2' --no-auto-run
 
 # Install ddev
 RUN brew update && brew install drud/ddev/ddev


### PR DESCRIPTION
# The Problem/Issue/Bug
DrupalPod is currently using latest version of PhpStorm, but after some tests, it seems to have some glitches 😞 

## How this PR Solves The Problem
This PR installs the PhpStorm 2020.3.2, which was officially tested in Projector.

## Manual Testing Instructions
1. <a href="https://gitpod.io/#https://github.com/shaal/DrupalPod/pull/20" rel="nofollow"><img src="https://camo.githubusercontent.com/76e60919474807718793857d8eb615e7a50b18b04050577e5a35c19421f260a3/68747470733a2f2f676974706f642e696f2f627574746f6e2f6f70656e2d696e2d676974706f642e737667" data-canonical-src="" style="max-width:100%;"></a>
1. Wait until setup is complete.
1. Run `.gitpod/phpstorm.sh`
1. A popup message will appear, click on `Open Browser` button
1. Try breaking PhpStorm 😁 

## Related Issue Link(s)

## Release/Deployment notes
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->


<a href="https://gitpod.io/#https://github.com/shaal/DrupalPod/pull/20"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

