### PR TITLE
Generate Gitpod URI for Drush

### DIFF
--- a/.gitpod/setup-ddev.sh
+++ b/.gitpod/setup-ddev.sh
@@ -33,6 +33,8 @@ cat <<COMPOSEEND >"${DDEV_DIR}"/docker-compose.host-docker-internal.yaml
 version: "3.6"
 services:
   web:
+    environment:
+      - DRUSH_OPTIONS_URI=$(gp url 8080)
     extra_hosts:
     - "host.docker.internal:${hostip}"
     # This adds 8080 on the host (bound on all interfaces)


### PR DESCRIPTION
# The Problem/Issue/Bug
Running commands like `ddev drush uli` is generating a URL that would not work on Gitpod.

## How this PR Solves The Problem
It generates the current Gitpod URI as a Drush variable.

## Manual Testing Instructions
1. Open DrupalPod workspace
1. `ddev drush si standard`
1. `ddev drush uli`
1. Confirm you can open the URL drush generated.

## Related Issue Link(s)

## Release/Deployment notes
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->


<a href="https://gitpod.io/#https://github.com/shaal/DrupalPod/pull/24"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

