### PR TITLE
Wipe database when no site-install was requested

### DIFF
--- a/.gitpod/drupal/drupalpod-setup.sh
+++ b/.gitpod/drupal/drupalpod-setup.sh
@@ -56,6 +56,9 @@ GITMODULESEND
     # Start ddev
     ddev start
 
+    # Wipe database from prebuild's Umami site install
+    ddev drush sql-drop -y
+
     # If project type is core, run composer install
     if [ "$DP_PROJECT_TYPE" == "project_core" ]; then
         cd "${GITPOD_REPO_ROOT}" && ddev composer install

--- a/.gitpod/drupal/drupalpod-setup.sh
+++ b/.gitpod/drupal/drupalpod-setup.sh
@@ -56,9 +56,6 @@ GITMODULESEND
     # Start ddev
     ddev start
 
-    # Wipe database from prebuild's Umami site install
-    ddev drush sql-drop -y
-
     # If project type is core, run composer install
     if [ "$DP_PROJECT_TYPE" == "project_core" ]; then
         cd "${GITPOD_REPO_ROOT}" && ddev composer install
@@ -87,6 +84,9 @@ GITMODULESEND
         elif [ "$DP_PROJECT_TYPE" == "project_theme" ]; then
             ddev drush then -y "$DP_PROJECT_NAME"
         fi
+    else
+        # Wipe database from prebuild's Umami site install
+        ddev drush sql-drop -y
     fi
 
     # Update HTTP repo to SSH repo


### PR DESCRIPTION
# The Problem/Issue/Bug
Due to site-install of Umami by default during prebuild,
When a user doesn't choose a site-install option, it becomes a problem because the site-install during prebuild was installed with Drupal 9.2.x

## How this PR Solves The Problem
When a user doesn't choose a site-install option - dump the database.

## Manual Testing Instructions

## Related Issue Link(s)

## Release/Deployment notes
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->


<a href="https://gitpod.io/#https://github.com/shaal/DrupalPod/pull/29"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

