### PR TITLE
Adds phpunit and nightwatch testing capability

### DIFF
--- a/.ddev/commands/web/nightwatch
+++ b/.ddev/commands/web/nightwatch
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+## Description: Run Nightwatch
+## Usage: nightwatch [flags] [args]
+## Example: "ddev nightwatch" or "ddev nightwatch --tag core"
+
+# Installs dependencies if not already run.
+if [ ! -d /var/www/html/web/core/node_modules ]; then
+  yarn --cwd /var/www/html/web/core install
+fi
+
+yarn --cwd /var/www/html/web/core test:nightwatch $@
+

--- a/.ddev/commands/web/phpunit
+++ b/.ddev/commands/web/phpunit
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+## Description: Run PHPUnit
+## Usage: phpunit [flags] [args]
+## Example: "ddev phpunit --group big_pipe" or "ddev phpunit web/core/modules/action"
+
+php ./vendor/bin/phpunit -c web/core/phpunit.xml.dist $@

--- a/.ddev/commands/web/phpunit
+++ b/.ddev/commands/web/phpunit
@@ -2,12 +2,14 @@
 
 ## Description: Run PHPUnit
 ## Usage: phpunit [flags] [args]
-## Example: "ddev phpunit --group big_pipe" or "ddev phpunit web/core/modules/action"
+## Example: "ddev phpunit --group big_pipe" or "ddev phpunit core/modules/action"
 
 mkdir -p /var/www/html/web/sites/simpletest/browser_output
+
+cd web
 
 BROWSERTEST_OUTPUT_DIRECTORY=/var/www/html/web/sites/simpletest/browser_output \
 BROWSERTEST_OUTPUT_BASE_URL=http://drupalpod.ddev.site \
 SIMPLETEST_DB="mysql://db:db@db/db" \
 SIMPLETEST_BASE_URL="http://localhost" \
-php ./vendor/bin/phpunit -c web/core/phpunit.xml.dist $@
+php ../vendor/bin/phpunit -c core/phpunit.xml.dist $@

--- a/.ddev/commands/web/phpunit
+++ b/.ddev/commands/web/phpunit
@@ -4,4 +4,10 @@
 ## Usage: phpunit [flags] [args]
 ## Example: "ddev phpunit --group big_pipe" or "ddev phpunit web/core/modules/action"
 
+mkdir -p /var/www/html/web/sites/simpletest/browser_output
+
+BROWSERTEST_OUTPUT_DIRECTORY=/var/www/html/web/sites/simpletest/browser_output \
+BROWSERTEST_OUTPUT_BASE_URL=http://drupalpod.ddev.site \
+SIMPLETEST_DB="mysql://db:db@db/db" \
+SIMPLETEST_BASE_URL="http://localhost" \
 php ./vendor/bin/phpunit -c web/core/phpunit.xml.dist $@

--- a/.ddev/docker-compose.testing.yaml
+++ b/.ddev/docker-compose.testing.yaml
@@ -1,0 +1,32 @@
+---
+# Adds Chromedriver and Drupal PHPUnit test environment variables for running tests.
+version: '3.6'
+services:
+  chromedriver:
+    image: drupalci/chromedriver:production
+    container_name: ddev-${DDEV_SITENAME}-chromedriver
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+
+  web:
+    links:
+      - chromedriver:$DDEV_HOSTNAME
+    environment:
+      # PHPUnit
+      SYMFONY_DEPRECATIONS_HELPER: weak
+      SIMPLETEST_DB: mysql://db:db@db:3306/db
+      SIMPLETEST_BASE_URL: http://localhost
+      BROWSERTEST_OUTPUT_DIRECTORY: /var/www/html/private/browsertest_output
+      BROWSERTEST_OUTPUT_BASE_URL: $DDEV_PRIMARY_URL
+      MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless", "--no-sandbox"]}}, "http://chromedriver:9515"]'
+
+      # Nightwatch
+      DRUPAL_TEST_BASE_URL: http://web
+      DRUPAL_TEST_DB_URL: mysql://db:db@db:3306/db
+      DRUPAL_TEST_WEBDRIVER_HOSTNAME: chromedriver
+      DRUPAL_TEST_WEBDRIVER_PORT: 9515
+      DRUPAL_TEST_CHROMEDRIVER_AUTOSTART: 'false'
+      DRUPAL_TEST_WEBDRIVER_CHROME_ARGS: "--disable-gpu --headless --no-sandbox"
+      DRUPAL_NIGHTWATCH_OUTPUT: reports/nightwatch
+      DRUPAL_NIGHTWATCH_IGNORE_DIRECTORIES: node_modules,vendor,.*,sites/*/files,sites/*/private,sites/simpletest

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Drupal
-web/
-vendor/
+/web/
+/vendor/
 composer.json
 composer.lock
 .editorconfig

--- a/.gitpod/drupal/drupalpod-setup.sh
+++ b/.gitpod/drupal/drupalpod-setup.sh
@@ -112,6 +112,10 @@ GITMODULESEND
         fi
     fi
 
+    # Install phpunit/phpunit and phpspec/prophecy.
+    cd "${GITPOD_REPO_ROOT}" && ddev composer require --dev --no-update phpunit/phpunit --with-dependencies --no-progress
+    cd "${GITPOD_REPO_ROOT}" && ddev composer require --dev --no-update phpspec/prophecy-phpunit:^2 --no-progress --no-suggest
+
     # Install Drush
     cd "${GITPOD_REPO_ROOT}" && ddev composer require --no-update drush/drush:^10
 

--- a/.gitpod/drupal/drupalpod-setup.sh
+++ b/.gitpod/drupal/drupalpod-setup.sh
@@ -140,6 +140,13 @@ GITMODULESEND
     # Configure phpcs for drupal.
     vendor/bin/phpcs --config-set installed_paths vendor/drupal/coder/coder_sniffer
 
+    # Configure phpunit for drupal.
+    if [ -f web/core/phpunit.xml ]; then
+        cp web/core/phpunit.xml.dist web/core/phpunit.xml
+        sed -i 's#SIMPLETEST_BASE_URL" value="#SIMPLETEST_BASE_URL" value="http://drupalpod.ddev.site:8888#' web/core/phpunit.xml
+        sed -i 's#SIMPLETEST_DB" value="#SIMPLETEST_DB" value="mysql://db:db@db/db#' web/core/phpunit.xml
+    fi
+
     # Save a file to mark workspace already initiated, unless it was set up during 'init'
     if [ -z "$GITPOD_HEADLESS" ]; then
         touch /workspace/drupalpod_initiated.status

--- a/.gitpod/drupal/drupalpod-setup.sh
+++ b/.gitpod/drupal/drupalpod-setup.sh
@@ -107,7 +107,8 @@ GITMODULESEND
             ddev composer require --no-update \
             "drupal/core-composer-scaffold:""$DP_CORE_VERSION" \
             "drupal/core-project-message:""$DP_CORE_VERSION" \
-            "drupal/core-recommended:""$DP_CORE_VERSION"
+            "drupal/core-recommended:""$DP_CORE_VERSION" \
+            "drupal/core-dev:""$DP_CORE_VERSION"
         fi
     fi
 

--- a/.gitpod/drupal/drupalpod-setup.sh
+++ b/.gitpod/drupal/drupalpod-setup.sh
@@ -113,7 +113,7 @@ GITMODULESEND
     fi
 
     # Install phpunit/phpunit and phpspec/prophecy.
-    cd "${GITPOD_REPO_ROOT}" && ddev composer require --dev --no-update phpunit/phpunit --with-dependencies --no-progress
+    cd "${GITPOD_REPO_ROOT}" && ddev composer require --dev --no-update phpunit/phpunit --no-progress --no-suggest
     cd "${GITPOD_REPO_ROOT}" && ddev composer require --dev --no-update phpspec/prophecy-phpunit:^2 --no-progress --no-suggest
 
     # Install Drush

--- a/.gitpod/drupal/drupalpod-setup.sh
+++ b/.gitpod/drupal/drupalpod-setup.sh
@@ -140,13 +140,6 @@ GITMODULESEND
     # Configure phpcs for drupal.
     vendor/bin/phpcs --config-set installed_paths vendor/drupal/coder/coder_sniffer
 
-    # Configure phpunit for drupal.
-    if [ -f web/core/phpunit.xml ]; then
-        cp web/core/phpunit.xml.dist web/core/phpunit.xml
-        sed -i 's#SIMPLETEST_BASE_URL" value="#SIMPLETEST_BASE_URL" value="http://drupalpod.ddev.site:8888#' web/core/phpunit.xml
-        sed -i 's#SIMPLETEST_DB" value="#SIMPLETEST_DB" value="mysql://db:db@db/db#' web/core/phpunit.xml
-    fi
-
     # Save a file to mark workspace already initiated, unless it was set up during 'init'
     if [ -z "$GITPOD_HEADLESS" ]; then
         touch /workspace/drupalpod_initiated.status


### PR DESCRIPTION
# The Problem/Issue/Bug

We should be able to write and/or run Drupal tests in DrupalPod like we can do locally using ddev.

## How this PR Solves The Problem

- Adds a ddev phpunit command based on mglaman's bluehorndigital/drupal-testing-workshop repository, but using env variables directly so we don't need to modify phpunit.xml
- Adds drupal/core-dev dependency
- Adds phpunit/phpunit phpspec/prophecy-phpunit dependencies, which assumes 
- Adds chromedriver docker service based on mglaman's bluehorndigital/drupal-testing-workshop repository.
- Adds a ddev nightwatch command, which also will install yarn packages

## Manual Testing Instructions

Run `ddev phpunit core/modules/action`
Run `ddev nightwatch tests/Drupal/Nightwatch/Tests/exampleTest.js`

## Related Issue Link(s)

#21 

## Release/Deployment notes
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->
