### PR TITLE
chore(#51): update composer version hash

### DIFF
--- a/.gitpod/.gitpod.Dockerfile
+++ b/.gitpod/.gitpod.Dockerfile
@@ -25,5 +25,3 @@ RUN php -r "if (hash_file('sha384', 'composer-setup.php') === '906a84df04cea2aa7
 RUN sudo php composer-setup.php --install-dir /usr/bin --filename composer
 RUN php -r "unlink('composer-setup.php');"
 
-### Initiate a rebuild of Gitpod's image by updating this comment #5
-###


### PR DESCRIPTION
# The Problem/Issue/Bug

Composer version has update, hash checking will fail if image rebuilds.

## How this PR Solves The Problem

Updates the hash.

## Manual Testing Instructions

Rebuild image.

## Related Issue Link(s)

Resolves #51 

## Release/Deployment notes
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->


<a href="https://gitpod.io/#https://github.com/shaal/DrupalPod/pull/52"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

