### PR TITLE
fix composer install when no ready-made-env exist

### DIFF
--- a/.gitpod/drupal/drupalpod-setup.sh
+++ b/.gitpod/drupal/drupalpod-setup.sh
@@ -270,7 +270,8 @@ GITMODULESEND
 
         # Install from scratch, if a full site install is required or ready-made-env doesn't exist
         if [ -n "$DP_REINSTALL" ] || [ ! "$ready_made_env_exist" ]; then
-            # @TODO - should ddev be restarted here?
+            # restart ddev - so settings.php gets updated to include settings.ddev.php
+            ddev restart
 
             # New site install
             ddev drush si -y --account-pass=admin --site-name="DrupalPod" "$DP_INSTALL_PROFILE"

--- a/.gitpod/drupal/drupalpod-setup.sh
+++ b/.gitpod/drupal/drupalpod-setup.sh
@@ -239,8 +239,14 @@ GITMODULESEND
         else
             cd "${GITPOD_REPO_ROOT}" && time ddev composer config repositories.lenient composer https://packages.drupal.org/lenient
             cd "${GITPOD_REPO_ROOT}" && time ddev composer require \
-                                        drush/drush:^11 \
+                                        drush/drush \
                                         drupal/coder
+
+            # Download extra modules
+            if [ -n "$EXTRA_MODULES" ]; then
+                cd "${GITPOD_REPO_ROOT}" && \
+                ddev composer require "$ADMIN_TOOLBAR_PACKAGE"
+            fi
         fi
 
         # Set special setup for composer for working on Drupal core
@@ -264,6 +270,8 @@ GITMODULESEND
 
         # Install from scratch, if a full site install is required or ready-made-env doesn't exist
         if [ -n "$DP_REINSTALL" ] || [ ! "$ready_made_env_exist" ]; then
+            # @TODO - should ddev be restarted here?
+
             # New site install
             ddev drush si -y --account-pass=admin --site-name="DrupalPod" "$DP_INSTALL_PROFILE"
 

--- a/.gitpod/drupal/envs-prep/create-environments.sh
+++ b/.gitpod/drupal/envs-prep/create-environments.sh
@@ -50,7 +50,7 @@ for d in "${allDrupalSupportedVersions[@]}"; do
   cd "$WORK_DIR"/"$d" && \
     ddev composer require \
       drupal/admin_toolbar \
-      drush/drush:^10 \
+      drush/drush \
       drupal/coder \
       drupal/devel
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,10 +17,8 @@
         {
             "type": "bashdb",
             "request": "launch",
-            "name": "Bash-Debug (select script from list of sh files)",
-            "cwd": "${workspaceFolder}",
-            "program": "${command:SelectScriptName}",
-            "args": []
+            "name": "Bash-Debug (simplest configuration)",
+            "program": "${file}"
         }
     ]
 }


### PR DESCRIPTION
# The Problem/Issue/Bug
Fixes https://github.com/shaal/DrupalPod/issues/64

## How this PR Solves The Problem
* There was an issue with `composer create-project`, when there were no ready-made-envs for that drupal version.
* Adding `DP_PHP_VERSION=8.0` in URL params (will become an official option when new browser extension is released)
* TODO: There's an issue with `drush si`, it doesn't connect to ddev's `db`, and try to work with `drupal` database instead.

## Manual Testing Instructions
Open this URL - 
https://gitpod.io/#DP_PROJECT_NAME=drupal,DP_ISSUE_FORK=drupal-3257163,DP_ISSUE_BRANCH=feature%2F3257163-drupal_media_bundle,DP_PROJECT_TYPE=project_core,DP_MODULE_VERSION=10.0.x,DP_CORE_VERSION=10.0.x,DP_PATCH_FILE=,DP_INSTALL_PROFILE=standard,DP_PHP_VERSION=8.0/https://github.com/shaal/drupalpod/tree/drupal10

## Related Issue Link(s)

## Release/Deployment notes
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->


<a href="https://gitpod.io/#https://github.com/shaal/DrupalPod/pull/65"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

