### PR TITLE
Always use issue page core version

### DIFF
--- a/.gitpod/drupal/drupalpod-setup.sh
+++ b/.gitpod/drupal/drupalpod-setup.sh
@@ -51,9 +51,13 @@ export DP_EXTRA_DEVEL=1
 export DP_EXTRA_ADMIN_TOOLBAR=1
 
 # For Drupal core issues, that use branch, always use issue page core version
-if [ "$DP_PROJECT_TYPE" == "project_core" ] && [ "$DP_MODULE_VERSION" == '10.0.x' ]; then
+if [ "$DP_PROJECT_TYPE" == "project_core" ]; then
     export DP_CORE_VERSION="$DP_MODULE_VERSION"
-    export DP_EXTRA_DEVEL=0
+
+    # @todo Disable devel module until it's compatible with Drupal 10
+    if [ "$DP_MODULE_VERSION" == '10.0.x' ]; then
+        export DP_EXTRA_DEVEL=0
+    fi
 fi
 
 # Use PHP 8.1 for Drupal 10.0.x


### PR DESCRIPTION
# The Problem/Issue/Bug
Currently only Drupal10 issues override DrupalPod browser extension selection.

## How this PR Solves The Problem
This PR make all core issues override DrupalPod browser extension selection.

## Manual Testing Instructions

## Related Issue Link(s)

## Release/Deployment notes
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->
