### PR TITLE
MTU fix - set docker-compose MTU to 1440

### DIFF
--- a/.ddev/docker-compose.network-mtu.yaml
+++ b/.ddev/docker-compose.network-mtu.yaml
@@ -1,10 +1,13 @@
-# docker-compose does not use the dockerd MTU value.
+# Since Gitpod removed slirp4netns as part of performance improvements,
+# MTU value should be aligned to the one in gitpod.io
 #
-# A permanent fix is being worked on -
-# https://github.com/gitpod-io/gitpod/pull/9356
-# https://github.com/gitpod-io/gitpod/pull/9360
+# Gitpod fixed it for docker - https://github.com/gitpod-io/gitpod/pull/9356
+# and for docker-compose - https://github.com/gitpod-io/template-docker-compose/pull/4
 #
-# Temporary solution - manually set the MTU value to 1440
+# ddev doesn't use Gitpod's custom docker-compose binary. Instead, ddev uses 
+# its own docker-compose binary at /home/gitpod/.ddev/bin/docker-compose
+# 
+# Align the MTU value to the one that is set in Gitpod (1440)
 
 networks:
   default:

--- a/.ddev/docker-compose.network-mtu.yaml
+++ b/.ddev/docker-compose.network-mtu.yaml
@@ -1,0 +1,12 @@
+# docker-compose does not use the dockerd MTU value.
+#
+# A permanent fix is being worked on -
+# https://github.com/gitpod-io/gitpod/pull/9356
+# https://github.com/gitpod-io/gitpod/pull/9360
+#
+# Temporary solution - manually set the MTU value to 1440
+
+networks:
+  default:
+    driver_opts:
+      com.docker.network.driver.mtu: 1440


### PR DESCRIPTION
# The Problem/Issue/Bug
Since yesterday (April 15) running `composer` through ddev in Gitpod, resulted in errors.
This seems to be related to Fastly endpoints, and wrong MTU value in docker-compose - https://github.com/gitpod-io/gitpod/issues/9354

A permanent solution is being worked on - https://github.com/gitpod-io/gitpod/pull/9356

## How this PR Solves The Problem
Set the correct MTU level (1440) manually

## Manual Testing Instructions
In terminal type `ddev ssh`
Run 10 times -
* `curl https://www.drupal.org`

## Related Issue Link(s)

## Release/Deployment notes
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->
