### PR TITLE
expose ports 3000 and 5000 from container

### DIFF
--- a/.ddev/docker-compose.ports.yaml
+++ b/.ddev/docker-compose.ports.yaml
@@ -1,0 +1,8 @@
+# Expose port 3000 of ddev's web container.
+version: '3.6'
+services:
+  web:
+    # ports are a list of exposed *container* ports
+    ports:
+      - 3000:3000
+      - 5000:5000

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -34,8 +34,14 @@ vscode:
     - rogalmic.bash-debug
 
 ports:
+  # Used by JS projects
+  - port: 3000
+    onOpen: ignore
   # Used by ddev - local db clients
   - port: 3306
+    onOpen: ignore
+  # Used by JS projects
+  - port: 5000
     onOpen: ignore
   # Used by MailHog
   - port: 8027


### PR DESCRIPTION
# The Problem/Issue/Bug
Running `ddev npx serve` runs inside ddev container, but hidden from Gitpod.

## How this PR Solves The Problem
Expose ports 3000 and 5000 so it can be viewed through Gitpod's URLs.

## Manual Testing Instructions
1. In terminal, type `ddev npx serve -l 3000`
1. Confirm you can view Gitpod port 3000 in the browser
1. In terminal, type `ddev npx serve -l 5000`
1. Confirm you can view Gitpod port 5000 in the browser

## Related Issue Link(s)

## Release/Deployment notes
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->


<a href="https://gitpod.io/#https://github.com/shaal/DrupalPod/pull/85"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

