### PR TITLE
Devel 5 required for Drupal 10

### DIFF
--- a/.gitpod/drupal/drupalpod-setup.sh
+++ b/.gitpod/drupal/drupalpod-setup.sh
@@ -58,7 +58,7 @@ if [ "$DP_PROJECT_TYPE" == "project_core" ]; then
 
     # @todo Disable devel module until it's compatible with Drupal 10
     if [ "$DP_MODULE_VERSION" == '10.0.x' ]; then
-        export DP_EXTRA_DEVEL=0
+        export DP_EXTRA_DEVEL="drupal/devel:^5.0@beta"
     fi
 fi
 

--- a/.gitpod/drupal/drupalpod-setup.sh
+++ b/.gitpod/drupal/drupalpod-setup.sh
@@ -20,7 +20,12 @@ fi
 
 # Check if additional modules should be installed
 export DEVEL_NAME="devel"
-export DEVEL_PACKAGE="drupal/devel:^4.1"
+# Install devel compatible with drupal core version
+if [ "$DP_CORE_VERSION" == '10.0.x' ]; then
+    export DEVEL_PACKAGE="drupal/devel:^5.0@beta"
+else
+    export DEVEL_PACKAGE="drupal/devel:^4.1"
+fi
 
 export ADMIN_TOOLBAR_NAME="admin_toolbar_tools"
 export ADMIN_TOOLBAR_PACKAGE="drupal/admin_toolbar:^3.1"
@@ -56,7 +61,7 @@ export DP_EXTRA_ADMIN_TOOLBAR=1
 if [ "$DP_PROJECT_TYPE" == "project_core" ]; then
     export DP_CORE_VERSION="$DP_MODULE_VERSION"
 
-    # @todo Disable devel module until it's compatible with Drupal 10
+    # Install devel compatible with drupal 10.x
     if [ "$DP_MODULE_VERSION" == '10.0.x' ]; then
         export DP_EXTRA_DEVEL="drupal/devel:^5.0@beta"
     fi

--- a/.gitpod/drupal/drupalpod-setup.sh
+++ b/.gitpod/drupal/drupalpod-setup.sh
@@ -60,11 +60,6 @@ export DP_EXTRA_ADMIN_TOOLBAR=1
 # For Drupal core issues, that use branch, always use issue page core version
 if [ "$DP_PROJECT_TYPE" == "project_core" ]; then
     export DP_CORE_VERSION="$DP_MODULE_VERSION"
-
-    # Install devel compatible with drupal 10.x
-    if [ "$DP_MODULE_VERSION" == '10.0.x' ]; then
-        export DP_EXTRA_DEVEL="drupal/devel:^5.0@beta"
-    fi
 fi
 
 # Use PHP 8.1 for Drupal 10.0.x

--- a/.gitpod/drupal/envs-prep/create-environments.sh
+++ b/.gitpod/drupal/envs-prep/create-environments.sh
@@ -57,17 +57,12 @@ for d in "${allDrupalSupportedVersions[@]}"; do
 
   # Install additional packages
 
-  # @todo: temporary fix until devel works with drupal 10.x
   # devel
   if [ "$d" == '10.0.x' ]; then
     COMPOSER_DEVEL='drupal/devel:^5.0@beta'
   else
     COMPOSER_DEVEL='drupal/devel'
   fi
-
-  # @todo: temporary fix until devel works with drupal 10.x
-  # replace $COMPOSER_DEVEL with drupal/devel
-  rm "$WORK_DIR"/"$d"/composer.lock
 
   # Install phpunit and its dependency - core-dev
   cd "$WORK_DIR"/"$d" && ddev composer require --dev phpspec/prophecy-phpunit:^2 drupal/core-dev:* -W --no-install

--- a/.gitpod/drupal/envs-prep/create-environments.sh
+++ b/.gitpod/drupal/envs-prep/create-environments.sh
@@ -60,7 +60,7 @@ for d in "${allDrupalSupportedVersions[@]}"; do
   # @todo: temporary fix until devel works with drupal 10.x
   # devel
   if [ "$d" == '10.0.x' ]; then
-    COMPOSER_DEVEL=''
+    COMPOSER_DEVEL='drupal/devel:^5.0@beta'
   else
     COMPOSER_DEVEL='drupal/devel'
   fi
@@ -89,20 +89,10 @@ for d in "${allDrupalSupportedVersions[@]}"; do
 
     echo "*** Adding extra modules"
 
-    # @todo: temporary fix until devel works with drupal 10.x
-    # devel
-    if [ "$d" == '10.0.x' ]; then
-      ENABLE_DEVEL=''
-    else
-      ENABLE_DEVEL='devel'
-    fi
-
-    # @todo: temporary fix until devel works with drupal 10.x
-    # replace $ENABLE_DEVEL with devel
     cd "$WORK_DIR"/"$d"  && \
       ddev drush en -y \
       admin_toolbar \
-      $ENABLE_DEVEL
+      devel
 
     # Enable Claro as default admin theme
     echo "*** Enable Claro theme"


### PR DESCRIPTION
# The Problem/Issue/Bug
During the workspace spinning up I get this error

Your requirements could not be resolved to an installable set of packages.

```
  Problem 1
    - Root composer.json requires drupal/devel ^4.1 -> satisfiable by drupal/devel[4.1.0, ..., 4.x-dev].
    - drupal/devel[4.1.0, ..., 4.x-dev] require drupal/core ^8.8 || ^9 -> found drupal/core[8.8.0-alpha1, ..., 8.9.x-dev, 9.0.0-alpha1, ..., 9.5.x-dev] but the package is fixed to 10.0.0-alpha6 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.

Installation failed, reverting ./composer.json and ./composer.lock to their original content.
composer [require drush/drush:^11.0 drupal/coder:^8.3 drupal/devel:^4.1 drupal/admin_toolbar:^3.1] failed, composer command failed: exit status 2. stderr=
```

## How this PR Solves The Problem
Install the [5.0.0-beta1](https://www.drupal.org/project/devel/releases/5.0.0-beta1) version of devel module.

## Manual Testing Instructions
@shaal I need help to understand how can I test it because I am newbie on DrupalPod.

## Related Issue Link(s)
#97 

## Release/Deployment notes
Closes #97 
