### PR TITLE
Use drupal/devel 5 to be compatible with Drupal 10.1.x.

### DIFF
--- a/.gitpod/drupal/drupalpod-setup.sh
+++ b/.gitpod/drupal/drupalpod-setup.sh
@@ -20,7 +20,7 @@ fi
 
 # Check if additional modules should be installed
 export DEVEL_NAME="devel"
-export DEVEL_PACKAGE="drupal/devel:^4.1"
+export DEVEL_PACKAGE="drupal/devel:^5"
 
 export ADMIN_TOOLBAR_NAME="admin_toolbar_tools"
 export ADMIN_TOOLBAR_PACKAGE="drupal/admin_toolbar:^3.1"
@@ -55,11 +55,6 @@ export DP_EXTRA_ADMIN_TOOLBAR=1
 # For Drupal core issues, that use branch, always use issue page core version
 if [ "$DP_PROJECT_TYPE" == "project_core" ]; then
     export DP_CORE_VERSION="$DP_MODULE_VERSION"
-
-    # @todo Disable devel module until it's compatible with Drupal 10
-    if [ "$DP_MODULE_VERSION" == '10.0.x' ]; then
-        export DP_EXTRA_DEVEL=0
-    fi
 fi
 
 # Use PHP 8.1 for Drupal 10.0.x


### PR DESCRIPTION
# The Problem/Issue/Bug
I am mentoring some people at Drupalcon Prague and we are seeing some failures in the console when the project tries to add devel for installations that use drupal 10.1.x (the workaround only works for 10.0.x).

## How this PR Solves The Problem
Since devel 5 is compatible with Drupal 10, use that instead to cover Drupal 9 and 10.
I am doing this change blindly in the repo as I guess is quite a simple change.

## Manual Testing Instructions
I'm not sure


