### PR TITLE
feat: add drupal-smart-snippets extension

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -28,6 +28,7 @@ vscode:
     - wongjn.php-sniffer
     - neilbrayfield.php-docblocker
     - bmewburn.vscode-intelephense-client
+    - andrewdavidblum.drupal-smart-snippets
 
     # Twig extensions.
     - mblode.twig-language-2


### PR DESCRIPTION
Adds a drupal-specific extension to the `.gitpod.yml` file.

[Open VSX listing](https://open-vsx.org/extension/andrewdavidblum/drupal-smart-snippets)
[VS marketplace listing](https://marketplace.visualstudio.com/items?itemName=andrewdavidblum.drupal-smart-snippets)
