### PR TITLE
replace Remote Explorer instruction with Ports tab

### DIFF
--- a/src/vscode-extension/drupalpod-ext/src/help-content.ts
+++ b/src/vscode-extension/drupalpod-ext/src/help-content.ts
@@ -55,7 +55,7 @@ body {
               </ul>
             </li>
             <li><span class="emoji">⬅️</span> Press the “Explorer” button. You can access and modify files in Drupal core and contrib by going expanding the "repos" directory.</li>
-            <li><span class="emoji">⬅️</span> Go to the “Ports” tab below (adjacent to the “Terminal” tab). It shows the services provided by DrupalPod.
+            <li><span class="emoji">⬇️</span> Go to the “Ports” tab below (adjacent to the “Terminal” tab). It shows the services provided by DrupalPod.
               <ul>
                 <li>Find the “8080” item in the list.</li>
                 <li>Press the “Globe" button to open Drupal in a new tab or window.</li>


### PR DESCRIPTION
# The Problem/Issue/Bug
See issue.

## How this PR Solves The Problem
Updates instructions to point to "Ports" tab instead of "Remote Explorer" button.

## Manual Testing Instructions

## Related Issue Link(s)
Closes #111 

## Release/Deployment notes
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

"Documentation: Updated user instructions for accessing Drupal services in the DrupalPod extension for VSCode. Users are now directed to the 'Ports' tab instead of the 'Remote Explorer' button. This change simplifies the process of opening Drupal in a new tab or window by clicking the 'Globe' button next to the '8080' item in the list."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->