### PR TITLE
Skip the redirect on git clone

### DIFF
--- a/.gitpod/drupal/envs-prep/set-default-environment.sh
+++ b/.gitpod/drupal/envs-prep/set-default-environment.sh
@@ -17,4 +17,4 @@ cd "$GITPOD_REPO_ROOT" && rm -rf ../ready-made-envs
 
 # Clone Drupal core repo
 mkdir -p "${GITPOD_REPO_ROOT}"/repos
-cd "${GITPOD_REPO_ROOT}"/repos && time git clone https://git.drupalcode.org/project/drupal
+cd "${GITPOD_REPO_ROOT}"/repos && time git clone https://git.drupalcode.org/project/drupal.git/


### PR DESCRIPTION
# The Problem/Issue/Bug

I noticed this:

> warning: redirecting to https://git.drupalcode.org/project/drupal.git/

So might as well fix it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Chore: Updated the Drupal core repository cloning command in `.gitpod/drupal/envs-prep/set-default-environment.sh`. The updated command now includes ".git" at the end of the URL, ensuring that the full repository, including all branches and tags, is cloned. This change enhances the development environment setup process by providing complete access to the Drupal core repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->