### PR TITLE
Download all required DDEV docker images during prebuild

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,5 +1,5 @@
-name: DrupalPod
-type: drupal10
+name: drupalpod
+type: drupal9
 docroot: web
 php_version: "8.1"
 webserver_type: nginx-fpm
@@ -8,7 +8,7 @@ additional_hostnames: []
 additional_fqdns: []
 database:
     type: mariadb
-    version: "10.4"
+    version: "10.3"
 use_dns_when_possible: true
 composer_version: "2"
 web_environment: []

--- a/.ddev/docker-compose.ports.yaml
+++ b/.ddev/docker-compose.ports.yaml
@@ -1,5 +1,4 @@
 # Expose port 3000 and 5000 of DDEV's web container.
-version: '3.6'
 services:
   web:
     # ports are a list of exposed *container* ports

--- a/.ddev/docker-compose.testing.yaml
+++ b/.ddev/docker-compose.testing.yaml
@@ -1,6 +1,5 @@
 ---
 # Adds Chromedriver and Drupal PHPUnit test environment variables for running tests.
-version: '3.6'
 services:
   chromedriver:
     image: drupalci/chromedriver:production

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,7 +5,7 @@ image: drupalpod/drupalpod-gitpod-base:20230922
 tasks:
   - init: |
       .gitpod/utils/send-a-message-gcs.sh > /tmp/output1.txt
-      ddev debug download-images
+      .gitpod/utils/download-ddev-images.sh
       .gitpod/utils/ddev-in-gitpod-setup.sh
       .gitpod/drupal/envs-prep/prepare-environments-gcs.sh > /tmp/output2.txt
       .gitpod/drupal/envs-prep/set-default-environment.sh

--- a/.gitpod/utils/download-ddev-images.sh
+++ b/.gitpod/utils/download-ddev-images.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Record the start time
+start_time=$(date +%s)
+
+# Get the list of images using 'docker images' and filter out the header
+images=$(docker images | awk 'NR>1 {print $1":"$2}')
+
+echo "List of required docker images for DDEV:"
+echo "$images"
+echo "Downloading the above docker images"
+
+# Loop through each image and pull it
+for image in $images
+do
+    docker pull "$image"
+done
+
+# Record the end time
+end_time=$(date +%s)
+
+# Calculate the elapsed time
+elapsed_time=$((end_time - start_time))
+
+# Print the elapsed time
+echo "Finished downloading docker images in $elapsed_time seconds"


### PR DESCRIPTION
Fixes #119 and #120 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated the project name and downgraded Drupal version from 10 to 9 in `.ddev/config.yaml`.
- Chore: Adjusted the database version from "10.4" to "10.3" in `.ddev/config.yaml`.
- Style: Modified indentation and removed version declaration in `.ddev/docker-compose.ports.yaml`.
- New Feature: Added a new service `chromedriver` using the `drupalci/chromedriver:production` image in `.ddev/docker-compose.testing.yaml`.
- Refactor: Replaced `ddev debug download-images` command with `.gitpod/utils/download-ddev-images.sh` in `.gitpod.yml`, indicating an update in the process of downloading images for debugging.
- Chore: Implemented a Bash script in `.gitpod/utils/download-ddev-images.sh` that downloads Docker images, improving efficiency and tracking time spent on this task.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->