### PR TITLE
Use less complicated method to download images

### DIFF
--- a/.gitpod/utils/download-ddev-images.sh
+++ b/.gitpod/utils/download-ddev-images.sh
@@ -3,18 +3,8 @@
 # Record the start time
 start_time=$(date +%s)
 
-# Get the list of images using 'docker images' and filter out the header
-images=$(docker images | awk 'NR>1 {print $1":"$2}')
-
-echo "List of required docker images for DDEV:"
-echo "$images"
-echo "Downloading the above docker images"
-
-# Loop through each image and pull it
-for image in $images
-do
-    docker pull "$image"
-done
+ddev debug download-images
+docker pull drupalci/chromedriver:production
 
 # Record the end time
 end_time=$(date +%s)


### PR DESCRIPTION
# The Problem/Issue/Bug

Currently there's a complex script to do the download, but it really only requires two lines

## How this PR Solves The Problem

Use the two lines. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Optimized the Docker image download process in the DDEV setup script. The updated code now uses the `ddev debug download-images` command, improving efficiency and focusing on pulling only necessary images.
- Chore: Specifically added the pull command for `drupalci/chromedriver:production` image to ensure its availability during the setup process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->