### PR TITLE
fix web/core not symlinked to repos/drupal/core

### DIFF
--- a/.gitpod/drupal/drupalpod-setup/drupal_setup_core.sh
+++ b/.gitpod/drupal/drupalpod-setup/drupal_setup_core.sh
@@ -31,7 +31,11 @@ cd "${GITPOD_REPO_ROOT}" &&
 # Removing the conflict part of composer
 echo "$(cat composer.json | jq 'del(.conflict)' --indent 4)" >composer.json
 
-# repos/drupal/vendor -> ../../vendor
+# Only after composer update, /web/core get symlinked to /repos/drupal/core
+# repos/drupal/core -> web/core
+time composer update --lock
+
+# vendor -> repos/drupal/vendor
 if [ ! -L "$GITPOD_REPO_ROOT"/repos/drupal/vendor ]; then
     cd "$GITPOD_REPO_ROOT"/repos/drupal &&
         ln -s ../../vendor .


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated composer.json and vendor directory to resolve conflicts and ensure compatibility.
- Chore: Created a symlink from `repos/drupal/vendor` to `../../vendor` for easier access to dependencies.
- Documentation: Updated composer.lock file using `composer update --lock` to reflect the latest package versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->