### PR TITLE
fix: update to latest ddev (v1.22.7)

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,14 +1,14 @@
 name: DrupalPod
 type: drupal10
 docroot: web
-php_version: "8.1"
+php_version: "8.3"
 webserver_type: nginx-fpm
 xdebug_enabled: false
 additional_hostnames: []
 additional_fqdns: []
 database:
     type: mariadb
-    version: "10.4"
+    version: "10.6"
 use_dns_when_possible: true
 composer_version: "2"
 web_environment: []
@@ -274,5 +274,6 @@ web_environment: []
 # for them. Example:
 #hooks:
 # post-import-db:
-#   - exec: drush cr
-#   - exec: drush updb
+#   - exec: drush sql:sanitize
+#   - exec: drush updatedb
+#   - exec: drush cache:rebuild

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: drupalpod/drupalpod-gitpod-base:20231222
+image: drupalpod/drupalpod-gitpod-base:20240306
 
 # DDEV and composer are running as part of the prebuild
 # when starting a workspace all docker images are ready

--- a/.gitpod/images/Dockerfile
+++ b/.gitpod/images/Dockerfile
@@ -15,13 +15,13 @@ RUN echo "deb [signed-by=/etc/apt/keyrings/ddev.gpg] https://pkg.ddev.com/apt/ *
 RUN sudo apt update && sudo apt install -y ddev
 
 # Install GitUI (terminal-ui for git)
-RUN wget https://github.com/extrawurst/gitui/releases/download/v0.24.3/gitui-linux-musl.tar.gz -P /tmp
+RUN wget https://github.com/extrawurst/gitui/releases/download/v0.25.1/gitui-linux-musl.tar.gz -P /tmp
 RUN sudo tar xzf /tmp/gitui-linux-musl.tar.gz -C /usr/bin
 
 # (get latest Minio version from https://dl.min.io/client/mc/release/linux-amd64/)
 # Install Minio client
-RUN wget https://dl.min.io/client/mc/release/linux-amd64/mcli_20231220071422.0.0_amd64.deb
-RUN sudo dpkg -i mcli_20231220071422.0.0_amd64.deb
+RUN wget https://dl.min.io/client/mc/release/linux-amd64/mcli_20240303001308.0.0_amd64.deb
+RUN sudo dpkg -i mcli_20240303001308.0.0_amd64.deb
 RUN sudo mv /usr/local/bin/mcli /usr/local/bin/mc
 
 # End workspace-base


### PR DESCRIPTION
I am still getting an error when running `ddev drush si demo_umami -y`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated PHP version to 8.3 and database version to 10.6 to enhance performance and security.
	- Improved post-database import processes for better data handling and application updates.
	- Updated the Gitpod base image and tools for a more current development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->