### PR TITLE
fix: improve fallback setup

### DIFF
--- a/.gitpod/drupal/drupalpod-setup/contrib_modules_setup.sh
+++ b/.gitpod/drupal/drupalpod-setup/contrib_modules_setup.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eu -o pipefail
 
 # Check if additional modules should be installed
 export DEVEL_NAME="devel"

--- a/.gitpod/drupal/drupalpod-setup/drupalpod-setup.sh
+++ b/.gitpod/drupal/drupalpod-setup/drupalpod-setup.sh
@@ -44,9 +44,14 @@ convert_version() {
 # echo $(convert_version "11.0-dev")      # Output: 11.x
 
 # Skip setup if it already ran once and if no special setup is set by DrupalPod extension
-if [ ! -f "${GITPOD_REPO_ROOT}"/.drupalpod_initiated ] && [ -n "$DP_PROJECT_TYPE" ]; then
-    source "$DIR/git_setup.sh"
+if [ ! -f "${GITPOD_REPO_ROOT}"/.drupalpod_initiated ]; then
 
+    # Set a default setup if project type wasn't specified
+    if [ -z "$DP_PROJECT_TYPE" ]; then
+        source "$DIR/fallback_setup.sh"
+    fi
+
+    source "$DIR/git_setup.sh"
 
     # If this is an issue fork of Drupal core - set the drupal core version based on that issue fork
     if [ "$DP_PROJECT_TYPE" == "project_core" ] && [ -n "$DP_ISSUE_FORK" ]; then
@@ -60,8 +65,7 @@ if [ ! -f "${GITPOD_REPO_ROOT}"/.drupalpod_initiated ] && [ -n "$DP_PROJECT_TYPE
     # Measure the time it takes to go through the script
     script_start_time=$(date +%s)
 
-    source "$DIR/fallback_setup.sh"
-    source "$DIR/install_modules.sh"
+    source "$DIR/contrib_modules_setup.sh"
     source "$DIR/cleanup.sh"
     source "$DIR/composer_setup.sh"
 

--- a/.gitpod/drupal/drupalpod-setup/fallback_setup.sh
+++ b/.gitpod/drupal/drupalpod-setup/fallback_setup.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
+set -eu -o pipefail
 
-# Set a default setup if project type wasn't specified
-if [ -z "$DP_PROJECT_TYPE" ]; then
-    export DP_INSTALL_PROFILE='demo_umami'
-    export DP_PROJECT_TYPE='project_core'
-    export DP_PROJECT_NAME="drupal"
-    export DP_CORE_VERSION='10.2.5'
-    export DP_EXTRA_DEVEL=1
-    export DP_EXTRA_ADMIN_TOOLBAR=1
-fi
+# Set a default setup (when project type is not specified)
+export DP_INSTALL_PROFILE='demo_umami'
+export DP_PROJECT_TYPE='project_core'
+export DP_PROJECT_NAME="drupal"
+export DP_CORE_VERSION='10.2.5'
+export DP_EXTRA_DEVEL=1
+export DP_EXTRA_ADMIN_TOOLBAR=1


### PR DESCRIPTION
This PR allow fallback setup when DrupalPod is called with no `DP_PROJECT_TYPE`.
That is the case when DrupalPod is called without using the browser extension.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the setup process for Drupal projects by streamlining the default setup and enhancing error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->