### PR TITLE
devops improvement: Don't add command warning to standard output.

### DIFF
--- a/.gitpod/utils/script-templates/ddev-composer.template.sh
+++ b/.gitpod/utils/script-templates/ddev-composer.template.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-echo "Notice: running 'composer $*' in ddev"
+>&2 echo "Notice: running 'composer $*' in ddev"
 ddev exec_d composer "$@"

--- a/.gitpod/utils/script-templates/ddev-drush.template.sh
+++ b/.gitpod/utils/script-templates/ddev-drush.template.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-echo "Notice: running 'drush $*' in ddev"
+>&2 echo "Notice: running 'drush $*' in ddev"
 ddev exec_d drush "$@"

--- a/.gitpod/utils/script-templates/ddev-node.template.sh
+++ b/.gitpod/utils/script-templates/ddev-node.template.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-echo "Notice: running 'node $*' in ddev"
+>&2 echo "Notice: running 'node $*' in ddev"
 ddev exec_d node "$@"

--- a/.gitpod/utils/script-templates/ddev-npx.template.sh
+++ b/.gitpod/utils/script-templates/ddev-npx.template.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-echo "Notice: running 'npx $*' in ddev"
+>&2 echo "Notice: running 'npx $*' in ddev"
 ddev exec_d npx "$@"

--- a/.gitpod/utils/script-templates/ddev-nvm.template.sh
+++ b/.gitpod/utils/script-templates/ddev-nvm.template.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-echo "Notice: running 'nvm $*' in ddev"
+>&2 echo "Notice: running 'nvm $*' in ddev"
 ddev exec_d nvm "$@"

--- a/.gitpod/utils/script-templates/ddev-php.template.sh
+++ b/.gitpod/utils/script-templates/ddev-php.template.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-echo "Notice: running 'php $*' in ddev"
+>&2 echo "Notice: running 'php $*' in ddev"
 ddev exec_d php "$@"

--- a/.gitpod/utils/script-templates/ddev-yarn.template.sh
+++ b/.gitpod/utils/script-templates/ddev-yarn.template.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-echo "Notice: running 'yarn $*' in ddev"
+>&2 echo "Notice: running 'yarn $*' in ddev"
 ddev exec_d yarn "$@"


### PR DESCRIPTION
# The Problem/Issue/Bug

When trying to run certain scripts, the warning added to the output is added directly to the standard output, and messes up the expected output.

## How this PR Solves The Problem

It adds the notice to the standard output stream instead.

Ideally this notice should be behind an environment variable.

## Manual Testing Instructions

```bash
php --version > /tmp/.php-version
# It shouldn't include the warning.
cat /tmp/.php-version
```
## Related Issue Link(s)

## Release/Deployment notes
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->
