### PR TITLE
Provide default if the variable is empty.

### DIFF
--- a/.gitpod/drupal/drupalpod-setup/drupalpod-setup.sh
+++ b/.gitpod/drupal/drupalpod-setup/drupalpod-setup.sh
@@ -89,6 +89,12 @@ if [ ! -f "${GITPOD_REPO_ROOT}"/.drupalpod_initiated ]; then
 
     # ddev config auto updates settings.php and generates settings.ddev.php
     ddev config --auto
+
+    # Set a default install profile if none was specified
+    if [ -z "$DP_INSTALL_PROFILE" ]; then
+        DP_INSTALL_PROFILE="minimal"
+    fi
+
     # New site install
     time ddev drush si -y --account-pass=admin --site-name="DrupalPod" "$DP_INSTALL_PROFILE"
 


### PR DESCRIPTION
# The Problem/Issue/Bug
https://github.com/shaal/DrupalPod/issues/156

## How this PR Solves The Problem
It sets a default value when none is set.

## Manual Testing Instructions
Trigger a Drupalpod creating without selecting a profile.

## Related Issue Link(s)
https://github.com/shaal/DrupalPod/issues/156

## Release/Deployment notes
The "minimal" profile will be selected if none is specified.